### PR TITLE
Add dynamic footer contributors + layout fixes

### DIFF
--- a/client/broadcast/message.html
+++ b/client/broadcast/message.html
@@ -151,7 +151,7 @@
     </nav>
 
     <!-- Main Content -->
-    <main id="broadcastMain" class="pt-0 md:pt-24 pb-20 md:pb-0 min-h-screen">
+    <main id="broadcastMain" class="pt-0 pb-0 min-h-screen">
       <div
         class="min-h-screen flex items-center justify-center p-4"
         style="
@@ -585,7 +585,7 @@
       </div>
     </main>
 
-    <footer class="py-12 px-6 mt-4 mb-20 md:mb-0 bg-gray-900 text-gray-300">
+    <footer class="py-12 px-6 mt-0 mb-20 md:mb-0 bg-gray-900 text-gray-300">
       <div class="max-w-7xl mx-auto">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-10">
           <div class="md:flex md:flex-col md:items-center md:text-center">

--- a/client/dashboard/home.html
+++ b/client/dashboard/home.html
@@ -829,6 +829,31 @@ async function deleteMessage(id) {
     }
 }
 
+ // Load contributors for footer
+      async function loadFooterContributors() {
+        try {
+          const response = await fetch(window.sirKothayContributorsApiUrl());
+          const contributors = await response.json();
+
+          const container = document.getElementById("contributorAvatars");
+          if (container) {
+            container.innerHTML = contributors
+              .slice(0, 6)
+              .map(
+                (c) =>
+                  `<a href="${c.html_url}" target="_blank">
+              <img src="${c.avatar_url}" class="h-8 w-8 rounded-full" alt="${c.login}">
+            </a>`,
+              )
+              .join("");
+          }
+        } catch (error) {
+          console.error("Error loading contributors:", error);
+        }
+      }
+
+      loadFooterContributors();
+
 // Load dashboard on page load
 loadDashboard();
 </script>
@@ -870,6 +895,9 @@ loadDashboard();
             <img src="https://github.com/UIU-Developers-Hub.png" class="h-8 w-8 rounded-full" alt="UIU Developers Hub">
             <span>© 2026 Sir Kothay. Made with ❤️ by <a href="https://github.com/UIU-Developers-Hub" style="color: #f68b1f;" class="hover:underline">UIU Developers Hub</a></span>
           </div>
+            <div id="contributorAvatars" class="flex gap-2 mt-2">
+              <!-- Contributors will be loaded dynamically -->
+            </div>
         </div>
       </div>
     </div>

--- a/client/dashboard/profile.html
+++ b/client/dashboard/profile.html
@@ -319,6 +319,31 @@ function showMessage(text, type) {
     }, 5000);
 }
 
+// Load contributors for footer
+      async function loadFooterContributors() {
+        try {
+          const response = await fetch(window.sirKothayContributorsApiUrl());
+          const contributors = await response.json();
+
+          const container = document.getElementById("contributorAvatars");
+          if (container) {
+            container.innerHTML = contributors
+              .slice(0, 6)
+              .map(
+                (c) =>
+                  `<a href="${c.html_url}" target="_blank">
+              <img src="${c.avatar_url}" class="h-8 w-8 rounded-full" alt="${c.login}">
+            </a>`,
+              )
+              .join("");
+          }
+        } catch (error) {
+          console.error("Error loading contributors:", error);
+        }
+      }
+
+      loadFooterContributors();
+
 // Load profile on page load
 loadProfile();
 </script>
@@ -360,6 +385,9 @@ loadProfile();
             <img src="https://github.com/UIU-Developers-Hub.png" class="h-8 w-8 rounded-full" alt="UIU Developers Hub">
             <span>© 2026 Sir Kothay. Made with ❤️ by <a href="https://github.com/UIU-Developers-Hub" style="color: #f68b1f;" class="hover:underline">UIU Developers Hub</a></span>
           </div>
+            <div id="contributorAvatars" class="flex gap-2 mt-2">
+              <!-- Contributors will be loaded dynamically -->
+            </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add loadFooterContributors() to dashboard/home.html and dashboard/profile.html to fetch contributors from window.sirKothayContributorsApiUrl(), render up to 6 avatar links into a new #contributorAvatars footer container, and invoke it on page load. Also adjust markup in client/broadcast/message.html to remove medium-screen top padding and clear bottom padding on the main element, and set footer top margin to mt-0 to tighten spacing. These changes surface contributor avatars in the footer and refine page spacing.