### PR TITLE
Update Firebase workflow to use upstream project

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY_TAHSINFAIYAZ30 }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY }}
           channelId: live
-          projectId: sir-kothay-tahsinfaiyaz30
+          projectId: sir-kothay
           entryPoint: client

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY_TAHSINFAIYAZ30 }}
-          projectId: sir-kothay-tahsinfaiyaz30
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY }}
+          projectId: sir-kothay
           entryPoint: client


### PR DESCRIPTION
This pull request updates the Firebase deployment configuration in the GitHub Actions workflows to use the correct Firebase project and service account. The changes ensure that deployments target the intended `sir-kothay` project instead of the previous `sir-kothay-tahsinfaiyaz30` project.

**Workflow configuration updates:**

* Updated the `firebaseServiceAccount` and `projectId` values in `.github/workflows/firebase-hosting-merge.yml` to use `FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY` and `sir-kothay`, respectively.
* Updated the `firebaseServiceAccount` and `projectId` values in `.github/workflows/firebase-hosting-pull-request.yml` to use `FIREBASE_SERVICE_ACCOUNT_SIR_KOTHAY` and `sir-kothay`, respectively.